### PR TITLE
Fix handling for output to the current directory

### DIFF
--- a/fontimize.py
+++ b/fontimize.py
@@ -143,7 +143,7 @@ def optimise_fonts(text : str, fonts : list[str], fontpath : str = "", subsetnam
     # By default, place it in the same folder as the respective font, unless fontpath is specified
     res["fonts"] = {} # dict of old font path -> new font path
     for font in fonts:
-        assetdir = fontpath if fontpath else path.dirname(font)
+        assetdir = fontpath or path.dirname(font) or "."
         t2w = TTF2Web(font, uranges, assetdir=assetdir)
         woff2_list = t2w.generateWoff2(verbosity=verbosity)
         # print(woff2_list)


### PR DESCRIPTION
The help text for `--outputdir` says it should default to the same directory as each input file, but if an input file is in the current directory and referenced without a path (i.e. `-f font.woff2`), this handling fails:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.10/site-packages/fontimize.py", line 429, in <module>
    res = optimise_fonts_for_files(_inputfiles,
  File "/usr/lib/python3.10/site-packages/fontimize.py", line 334, in optimise_fonts_for_files
    res = optimise_fonts(text, font_files, fontpath=font_output_dir, subsetname=subsetname, verbose=verbose, print_stats=print_stats)
  File "/usr/lib/python3.10/site-packages/fontimize.py", line 148, in optimise_fonts
    woff2_list = t2w.generateWoff2(verbosity=verbosity)
  File "/usr/lib/python3.10/site-packages/ttf2web.py", line 96, in generateWoff2
    os.makedirs(self.assetdir, exist_ok=True)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```

This fix will fall back to `.` as the asset directory if the result of `dirname(font)` is empty.